### PR TITLE
Reduce the number of dependencies of the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## PyTorchRL: A PyTorch library for reinforcement learning
 
-Deep Reinforcement learning (DRL) has been very successful in recent years but current methods still require vast amounts of data to solve non-trivial environments.  Scaling to solve more complex tasks requires frameworks that are flexible enough to allow prototyping and testing of new ideas, yet avoiding the impractically slow experimental turnaround times associated to single-threaded implementations.  PyTorchRL is a pytorch-based library for DRL that allows to easily assemble RL agents using a set of core reusable and easily extendable sub-modules as building blocks.  To reduce training times, PyTorchRL allows scaling agents with a parameterizable component called Scheme, that permits to define distributed architectures with great flexibility by specifying which operations should be decoupled, which should be parallelized, and how parallel tasks should be synchronized.
+Deep Reinforcement learning (DRL) has been very successful in recent years but current methods still require vast amounts of data to solve non-trivial environments. Scaling to solve more complex tasks requires frameworks that are flexible enough to allow prototyping and testing of new ideas, yet avoiding the impractically slow experimental turnaround times associated to single-threaded implementations. PyTorchRL is a pytorch-based library for DRL that allows to easily assemble RL agents using a set of core reusable and easily extendable sub-modules as building blocks. To reduce training times, PyTorchRL allows scaling agents with a parameterizable component called Scheme, that permits to define distributed architectures with great flexibility by specifying which operations should be decoupled, which should be parallelized, and how parallel tasks should be synchronized.
 
 ### Installation
 
@@ -9,8 +9,8 @@ Deep Reinforcement learning (DRL) has been very successful in recent years but c
     conda activate pytorchrl
 
     conda install pytorch torchvision cudatoolkit -c pytorch
-    
-    pip install pytorchrl
+
+    pip install pytorchrl gym[atari,accept-rom-license]==0.19.0 wandb opencv-python hydra-core
 ```
 
 ### Documentation
@@ -18,11 +18,12 @@ Deep Reinforcement learning (DRL) has been very successful in recent years but c
 PyTorchRL documentation can be found [here](https://pytorchrl.readthedocs.io/en/latest/).
 
 ### Citing PyTorchRL
+
 Here is the [paper](https://arxiv.org/abs/2007.02622)
 
 ```
 @misc{bou2021pytorchrl,
-      title={PyTorchRL: Modular and Distributed Reinforcement Learning in PyTorch}, 
+      title={PyTorchRL: Modular and Distributed Reinforcement Learning in PyTorch},
       author={Albert Bou and Gianni De Fabritiis},
       year={2021},
       eprint={2007.02622},

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -21,13 +21,14 @@ Installing PyTorchRL library
 3. Install package. It can be installed either via PyPI or from source. ::
 
     # PyPI installation
-    pip install pytorchrl
+    pip install pytorchrl gym[atari,accept-rom-license]==0.19.0 wandb opencv-python hydra-core
 
 
     # source installation
     git clone git@github.com:PyTorchRL/pytorchrl.git
     cd pytorchrl
-    python -m pip install -e .
+    pip install gym[atari,accept-rom-license]==0.19.0 wandb opencv-python hydra-core
+    pip install -e .
 
 4. To quickly test if installation was successful you can execute the following script, which runs a few training steps of the ``AC2`` algorithm on the ``CartPole-v0`` environment.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
-gym[atari]==0.19.0
-gym[accept-rom-license]==0.19.0
+gym==0.19.0
 ray[default]
 numpy
 pandas
 scipy
 lz4
 tqdm
-opencv-python
-wandb
-hydra-core


### PR DESCRIPTION
Reduce the number of dependencies of the package by removing optional deps from the requirements.

This is necessary to avoid licensing issues in commercial applications